### PR TITLE
RI omits whitespaces

### DIFF
--- a/src/ibus-fep.1
+++ b/src/ibus-fep.1
@@ -4,7 +4,7 @@
 ibus-fep \- IBus client for text terminals
 .SH SYNOPSIS
 .B ibus-fep
-.RI [-- commands]
+.RI [ \-\-\ commands ]
 .br
 .SH DESCRIPTION
 \fBibus-fep\fP is an IBus client for text terminals.


### PR DESCRIPTION
So ".RI [-- commands]" is rendered as "[--commands]",
"[--" in regular font and "commands]" in italic.
