### PR TITLE
Update the manual

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,22 +49,16 @@ GITIGNOREFILES =				\
 	fep_vala.stamp				\
 	$(NULL)
 
-EXTRA_DIST = config.vapi ibus-1.0.deps ibus-1.0.vapi ibus-fep.in fep.wrapper.in
-DISTCLEANFILES = ibus-fep fep.wrapper
+EXTRA_DIST = config.vapi ibus-1.0.deps ibus-1.0.vapi ibus-fep.in
+DISTCLEANFILES = ibus-fep
 
 feplibexecdir = $(pkglibexecdir)
-feplibexec_SCRIPTS = fep.wrapper
 
 bin_SCRIPTS = ibus-fep
 
 ibus-fep: ibus-fep.in
 	$(AM_V_GEN) sed -e "s!@FEP\@!"$(FEP)"!" \
-	-e "s!@WRAPPER\@!"$(pkglibexecdir)/fep.wrapper"!" \
-	$< > $@.tmp && \
-	mv $@.tmp $@
-
-fep.wrapper: fep.wrapper.in
-	$(AM_V_GEN) sed -e "s!@FEP\@!"$(pkglibexecdir)/fep"!" \
+	-e "s!@CLIENT\@!"$(pkglibexecdir)/fep"!" \
 	$< > $@.tmp && \
 	mv $@.tmp $@
 

--- a/src/ibus-fep.1
+++ b/src/ibus-fep.1
@@ -5,7 +5,9 @@ ibus\-fep - IBus client for text terminals
 .SH SYNOPSIS
 .B ibus\-fep
 .RI [ options ]
-.RI [ \-\-\ commands ]
+[\-\-
+.I command
+.RI [ args ]]
 .br
 .SH DESCRIPTION
 \fBibus\-fep\fP is an IBus client for text terminals.
@@ -14,14 +16,11 @@ ibus\-fep - IBus client for text terminals
 .B \-h, \-\-help
 Show summary of options.
 .TP
-.B \-s, \-\-style=\fISTYLE\fR
-Specify input style ("root" or over\-the\-spot).
-.TP
-.B \-t, \-\-temp
-Skip saving of input style.
-.TP
-.B \-n, \-\-noconf
-Skip loading and saving of input style.
+.B \-s, \-\-preedit\-style=\fISTYLE\fR
+Specify input style ("root" or "over\-the\-spot").
+The default is "over\-the\-spot" which shows preedit text at the cursor position.
+If you don't like it because it can overwrite the screen,
+use "root" which places preedit text at the bottom line of the screen.
 .SH EXAMPLE
 .TP
 $ pgrep \-lf ibus\-daemon

--- a/src/ibus-fep.1
+++ b/src/ibus-fep.1
@@ -1,27 +1,41 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
 .TH IBUS-FEP 1 "10 Feb 2012"
 .SH NAME
-ibus-fep \- IBus client for text terminals
+ibus\-fep - IBus client for text terminals
 .SH SYNOPSIS
-.B ibus-fep
+.B ibus\-fep
+.RI [ options ]
 .RI [ \-\-\ commands ]
 .br
 .SH DESCRIPTION
-\fBibus-fep\fP is an IBus client for text terminals.
+\fBibus\-fep\fP is an IBus client for text terminals.
+.SH OPTIONS
+.TP
+.B \-h, \-\-help
+Show summary of options.
+.TP
+.B \-s, \-\-style=\fISTYLE\fR
+Specify input style ("root" or over\-the\-spot).
+.TP
+.B \-t, \-\-temp
+Skip saving of input style.
+.TP
+.B \-n, \-\-noconf
+Skip loading and saving of input style.
 .SH EXAMPLE
 .TP
-$ pgrep \-lf ibus-daemon
+$ pgrep \-lf ibus\-daemon
 make sure that ibus-daemon is running
 .TP
 $ unset XMODIFIERS
 disable XIM
 .TP
-$ xterm \-e ibus-fep
-run a default shell program under ibus-fep
+$ xterm \-e ibus\-fep
+run a default shell program under ibus\-fep
 .TP
-$ xterm \-e ibus-fep \-\- nano
-run GNU nano instead of shell under ibus-fep
+$ xterm \-e ibus\-fep \-\- nano
+run GNU nano instead of shell under ibus\-fep
 .SH SEE ALSO
 \fBfep\fR(1), \fBxterm\fR(1)
 .SH AUTHOR
-ibus-fep was written by Daiki Ueno <ueno@unixuser.org>.
+ibus\-fep was written by Daiki Ueno <ueno@unixuser.org>.

--- a/src/ibus-fep.in
+++ b/src/ibus-fep.in
@@ -16,6 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 : ${FEP:=@FEP@}
-: ${WRAPPER:=@WRAPPER@}
+: ${CLIENT:=@CLIENT@}
 
-exec "$FEP" -- "$WRAPPER" "$@"
+exec "$FEP" -- "$CLIENT" "$@"

--- a/src/main.vala
+++ b/src/main.vala
@@ -16,26 +16,50 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const OptionEntry[] options = {
+string? opt_preedit_style = null;
+
+const OptionEntry entries[] = {
+    { "preedit-style", 's', 0, OptionArg.STRING,
+      out opt_preedit_style,
+      "Preedit style (default: over-the-spot)", "[root]" },
     { null }
 };
 
+static void close_child (Pid pid, int status) {
+    Process.close_pid (pid);
+    IBus.quit ();
+}
+
 static int main (string[] args) {
+    EnumClass preedit_style_class = (EnumClass) typeof(PreeditStyle).class_ref ();
     Intl.setlocale (LocaleCategory.ALL, "");
     Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALEDIR);
     Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");
     Intl.textdomain (Config.GETTEXT_PACKAGE);
 
-    var option_context = new OptionContext (
-        _("- IBus client for text terminals"));
-    option_context.add_main_entries (options, "ibus-fep");
+    var context = new OptionContext (
+        _("[-- COMMAND...]  - IBus client for text terminals"));
+    context.add_main_entries (entries, "ibus-fep");
+
+    stderr.printf("\n\n"); /* hack to show the first line */
     try {
-        option_context.parse (ref args);
+        context.parse (ref args);
     } catch (OptionError e) {
         stderr.printf ("%s\n", e.message);
         return 1;
     }
 
+    Options opts = Options () { preedit_style = PreeditStyle.DEFAULT };
+    if (opt_preedit_style != null) {
+        EnumValue? evalue = preedit_style_class.get_value_by_nick (
+            opt_preedit_style);
+        if (evalue == null) {
+            stderr.printf (_("unknown preedit style %s"), opt_preedit_style);
+            return 1;
+        }
+        opts.preedit_style = (PreeditStyle) evalue.value;
+    }
+        
     IBus.init ();
     var bus = new IBus.Bus ();
     if (!bus.is_connected ()) {
@@ -43,9 +67,49 @@ static int main (string[] args) {
         return 1;
     }
 
+    if (opt_preedit_style == null) {
+        var config = bus.get_config ();
+        Variant? values = config.get_values ("fep");
+        if (values != null) {
+            Variant? value = values.lookup_value ("preedit_style",
+                                                  VariantType.INT32);
+            if (value != null) {
+                EnumValue? evalue = preedit_style_class.get_value (
+                    value.get_int32 ());
+                if (evalue != null) {
+                    opts.preedit_style = (PreeditStyle) evalue.value;
+                } else {
+                    warning ("invalid preedit style %d - ignoring",
+                             value.get_int32 ());
+                }
+            }
+        }
+    }
+
+    string[]? argv;
+    if (args.length > 1) {
+        argv = args[1 : args.length];
+    } else {
+        argv = { Environment.get_variable ("SHELL") };
+    }
+
+    try {
+        Pid pid;
+        if (Process.spawn_async (
+                null, argv, null,
+                SpawnFlags.DO_NOT_REAP_CHILD |
+                SpawnFlags.CHILD_INHERITS_STDIN |
+                SpawnFlags.SEARCH_PATH,
+                null, out pid))
+            ChildWatch.add (pid, close_child);
+    } catch (SpawnError e) {
+        stderr.printf ("%s\n", e.message);
+        return 1;
+    }
+
     Client client;
     try {
-        client = new Client (bus);
+        client = new Client (bus, opts);
     } catch (Error e) {
         stderr.printf (_("can't create client: %s\n"), e.message);
         return 1;


### PR DESCRIPTION
- -t and -n is not implemented.
- --preedit-style instead of --style.
- "command [args]" instead of "commands" because "cmd1; cmd2; ..." is not allowed.
