### PR TITLE
Delete loading/saving code

### DIFF
--- a/src/main.vala
+++ b/src/main.vala
@@ -67,25 +67,6 @@ static int main (string[] args) {
         return 1;
     }
 
-    if (opt_preedit_style == null) {
-        var config = bus.get_config ();
-        Variant? values = config.get_values ("fep");
-        if (values != null) {
-            Variant? value = values.lookup_value ("preedit_style",
-                                                  VariantType.INT32);
-            if (value != null) {
-                EnumValue? evalue = preedit_style_class.get_value (
-                    value.get_int32 ());
-                if (evalue != null) {
-                    opts.preedit_style = (PreeditStyle) evalue.value;
-                } else {
-                    warning ("invalid preedit style %d - ignoring",
-                             value.get_int32 ());
-                }
-            }
-        }
-    }
-
     string[]? argv;
     if (args.length > 1) {
         argv = args[1 : args.length];


### PR DESCRIPTION
The "-s" commandline-option is enough because ibus-fep is not invoked frequently.
Most users have to write "ibus-fep" or "ibus-fep -s root" in a script only once.
If ibus-fep saves/loads settings, that should be documened somewhere.
